### PR TITLE
Patch to enable full-speed USB port C on at91sam9x5ek

### DIFF
--- a/arch/arm/boot/dts/at91sam9x5ek.dtsi
+++ b/arch/arm/boot/dts/at91sam9x5ek.dtsi
@@ -94,7 +94,7 @@
 
 		usb0: ohci@00600000 {
 			status = "okay";
-			num-ports = <2>;
+			num-ports = <3>;
 			atmel,vbus-gpio = <&pioD 19 1
 					   &pioD 20 1
 					  >;


### PR DESCRIPTION
Set num-ports to 3 for the at91sam9x5ek, enabling full-speed USB on port C
