### PR TITLE
pinctrl: at91: add drive strength config options

### DIFF
--- a/arch/arm/mach-at91/include/mach/at91_pio.h
+++ b/arch/arm/mach-at91/include/mach/at91_pio.h
@@ -66,6 +66,15 @@
 #define PIO_FRLHSR	0xd8	/* Fall/Rise - Low/High Status Register */
 #define PIO_SCHMITT	0x100	/* Schmitt Trigger Register */
 
+#if defined(CONFIG_SOC_SAMA5D3)
+	#define PIO_DRIVER1	0x118	/* Drive Strength Register 1 */
+	#define PIO_DRIVER2	0x11C	/* Drive Strength Register 2 */
+#else
+	//SAMA9x5,SAM9G35, SAM9G25
+	#define PIO_DRIVER1	0x114	/* Drive Strength Register 1 */
+	#define PIO_DRIVER2	0x118	/* Drive Strength Register 2 */
+#endif
+
 #define ABCDSR_PERIPH_A	0x0
 #define ABCDSR_PERIPH_B	0x1
 #define ABCDSR_PERIPH_C	0x2


### PR DESCRIPTION
The SAMA5 and SAMA92x5, SAM9G25 and SAM9G35 and others implement the ability to select the output drive strength for pins. But the pinctrl driver is currently missing the option to set it.

This patch only reserves 3 bits in the pinctrl config(bits 5,6 and 7) for drive strength. The first bit enables setting the drive strength, the other two bits(6,7) set the drive strength to the specified level which is dependent on the chip.

i.e. v9s:
00 = high
01 = medium
10 = low
11 = reserved/undefined

the A5 does
00 = low
01 = low
10 = medium
11 = high

Notes:
1. Only tested on SAMA5 because I don't have the eval boards for the others :(
2. The SAMA5 datasheet incorrectly states the default value for drivestrength config is 0x00000000. The real default value is 0xAAAAAAAA or medium strength for all pins. This can be confirmed with the JLINK on the SAMA5EK.
3. For some reason the Atmel engineers relocated the drivestrength registers between the SAMA5 and the SAM9s by a few addresses. The #if defined in at91_pio.h is a quick attempt to workaround that change depending on cpu.
