### PR TITLE
init can clock

### DIFF
--- a/arch/arm/mach-at91/at91sam9x5.c
+++ b/arch/arm/mach-at91/at91sam9x5.c
@@ -229,6 +229,8 @@ static struct clk_lookup periph_clocks_lookups[] = {
 	CLKDEV_CON_DEV_ID("usart", "f8028000.serial", &usart3_clk),
 	CLKDEV_CON_DEV_ID("usart", "f8040000.serial", &uart0_clk),
 	CLKDEV_CON_DEV_ID("usart", "f8044000.serial", &uart1_clk),
+	CLKDEV_CON_DEV_ID("can_clk", "f8000000.can", &can0_clk),
+	CLKDEV_CON_DEV_ID("can_clk", "f8004000.can", &can1_clk),
 	CLKDEV_CON_DEV_ID("t0_clk", "f8008000.timer", &tcb0_clk),
 	CLKDEV_CON_DEV_ID("t0_clk", "f800c000.timer", &tcb0_clk),
 	CLKDEV_CON_DEV_ID("mci_clk", "f0008000.mmc", &mmc0_clk),


### PR DESCRIPTION
fix initialisation of the can0 and can1 clock

During the register of the clock, the can clock wasn't added to the periph_clocks_lookups table.
The register of the clock can failed.
