### PR TITLE
Linux 3.15 at91 fixes

### DIFF
--- a/arch/arm/boot/dts/at91sam9260.dtsi
+++ b/arch/arm/boot/dts/at91sam9260.dtsi
@@ -435,6 +435,14 @@
 					};
 				};
 
+				i2c0 {
+					pinctrl_i2c0: i2c0-0 {
+						atmel,pins =
+							<0 23 0x1 0x0	/* PA23 periph A I2C0 data */
+							 0 24 0x1 0x0>;	/* PA24 periph A I2C0 clock */
+					};
+				};
+
 				pioA: gpio@fffff400 {
 					compatible = "atmel,at91rm9200-gpio";
 					reg = <0xfffff400 0x200>;
@@ -563,6 +571,8 @@
 				interrupts = <11 IRQ_TYPE_LEVEL_HIGH 6>;
 				#address-cells = <1>;
 				#size-cells = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&pinctrl_i2c0>;
 				status = "disabled";
 			};
 

--- a/arch/arm/boot/dts/at91sam9x5.dtsi
+++ b/arch/arm/boot/dts/at91sam9x5.dtsi
@@ -973,6 +973,9 @@
 				reg = <0xfffff200 0x200>;
 				interrupts = <1 IRQ_TYPE_LEVEL_HIGH 7>;
 				pinctrl-names = "default";
+				dmas = <&dma1 1 0x8>,
+				       <&dma1 1 0x209>;
+				dma-names = "tx", "rx";
 				pinctrl-0 = <&pinctrl_dbgu>;
 				clocks = <&mck>;
 				clock-names = "usart";
@@ -983,6 +986,9 @@
 				compatible = "atmel,at91sam9260-usart";
 				reg = <0xf801c000 0x200>;
 				interrupts = <5 IRQ_TYPE_LEVEL_HIGH 5>;
+				dmas = <&dma0 1 0x3>,
+				       <&dma0 1 0x204>;
+				dma-names = "tx", "rx";
 				pinctrl-names = "default";
 				pinctrl-0 = <&pinctrl_usart0>;
 				clocks = <&usart0_clk>;
@@ -994,6 +1000,9 @@
 				compatible = "atmel,at91sam9260-usart";
 				reg = <0xf8020000 0x200>;
 				interrupts = <6 IRQ_TYPE_LEVEL_HIGH 5>;
+				dmas = <&dma0 1 0x5>,
+				       <&dma0 1 0x204>;
+				dma-names = "tx", "rx";
 				pinctrl-names = "default";
 				pinctrl-0 = <&pinctrl_usart1>;
 				clocks = <&usart1_clk>;
@@ -1005,6 +1014,9 @@
 				compatible = "atmel,at91sam9260-usart";
 				reg = <0xf8024000 0x200>;
 				interrupts = <7 IRQ_TYPE_LEVEL_HIGH 5>;
+				dmas = <&dma1 1 0xc>,
+				       <&dma1 1 0x20d>;
+				dma-names = "tx", "rx";
 				pinctrl-names = "default";
 				pinctrl-0 = <&pinctrl_usart2>;
 				clocks = <&usart2_clk>;
@@ -1016,6 +1028,9 @@
 				compatible = "atmel,at91sam9260-usart";
 				reg = <0xf8028000 0x200>;
 				interrupts = <8 4 5>;
+				dmas = <&dma1 1 0xe>,
+				       <&dma1 1 0x20f>;
+				dma-names = "tx", "rx";
 				pinctrl-names = "default";
 				pinctrl-0 = <&pinctrl_usart3>;
 				clocks = <&usart3_clk>;

--- a/arch/arm/boot/dts/at91sam9x5.dtsi
+++ b/arch/arm/boot/dts/at91sam9x5.dtsi
@@ -26,6 +26,7 @@
 		serial1 = &usart0;
 		serial2 = &usart1;
 		serial3 = &usart2;
+		serial4 = &usart3;
 		gpio0 = &pioA;
 		gpio1 = &pioB;
 		gpio2 = &pioC;
@@ -275,6 +276,11 @@
 					usart2_clk: usart2_clk {
 						#clock-cells = <0>;
 						reg = <7>;
+					};
+
+					usart3_clk: usart3_clk {
+						#clock-cells = <0>;
+						reg = <8>;
 					};
 
 					twi0_clk: twi0_clk {
@@ -567,6 +573,29 @@
 					pinctrl_usart2_sck: usart2_sck-0 {
 						atmel,pins =
 							<AT91_PIOB 2 AT91_PERIPH_B AT91_PINCTRL_NONE>;	/* PB2 periph B */
+					};
+				};
+
+				usart3 {
+					pinctrl_usart3: usart3-0 {
+						atmel,pins =
+							<AT91_PIOC 22 AT91_PERIPH_B AT91_PINCTRL_PULL_UP	/* PC22 periph B with pullup */
+							 AT91_PIOC 23 AT91_PERIPH_B AT91_PINCTRL_NONE>;	/* PC23 periph B */
+					};
+
+					pinctrl_usart3_rts: usart3_rts-0 {
+						atmel,pins =
+							<AT91_PIOC 24 AT91_PERIPH_B AT91_PINCTRL_NONE>;	/* PC24 periph B */
+					};
+
+					pinctrl_usart3_cts: usart3_cts-0 {
+						atmel,pins =
+							<AT91_PIOC 25 AT91_PERIPH_B AT91_PINCTRL_NONE>;	/* PC25 periph B */
+					};
+
+					pinctrl_usart3_sck: usart3_sck-0 {
+						atmel,pins =
+							<AT91_PIOC 26 AT91_PERIPH_B AT91_PINCTRL_NONE>;	/* PC26 periph B */
 					};
 				};
 
@@ -979,6 +1008,17 @@
 				pinctrl-names = "default";
 				pinctrl-0 = <&pinctrl_usart2>;
 				clocks = <&usart2_clk>;
+				clock-names = "usart";
+				status = "disabled";
+			};
+
+			usart3: serial@f8028000 {
+				compatible = "atmel,at91sam9260-usart";
+				reg = <0xf8028000 0x200>;
+				interrupts = <8 4 5>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&pinctrl_usart3>;
+				clocks = <&usart3_clk>;
 				clock-names = "usart";
 				status = "disabled";
 			};

--- a/arch/arm/boot/dts/sama5d35ek.dts
+++ b/arch/arm/boot/dts/sama5d35ek.dts
@@ -20,6 +20,10 @@
 				status = "okay";
 			};
 
+			ssc0: ssc@f0008000 {
+				status = "okay";
+			};
+
 			can0: can@f000c000 {
 				status = "okay";
 			};

--- a/arch/arm/boot/dts/sama5d3xmb.dtsi
+++ b/arch/arm/boot/dts/sama5d3xmb.dtsi
@@ -43,10 +43,11 @@
 			 */
 			i2c0: i2c@f0014000 {
 				wm8904: wm8904@1a {
-					compatible = "wm8904";
+					compatible = "wlf,wm8904";
 					reg = <0x1a>;
 					clocks = <&pck0>;
 					clock-names = "mclk";
+					status = "okay";
 				};
 			};
 

--- a/drivers/clk/at91/clk-peripheral.c
+++ b/drivers/clk/at91/clk-peripheral.c
@@ -151,6 +151,14 @@ static void clk_sam9x5_peripheral_autodiv(struct clk_sam9x5_peripheral *periph)
 			if (parent_rate >> shift <= periph->range.max)
 				break;
 		}
+
+		if (shift == PERIPHERAL_MAX_SHIFT) {
+			shift--;
+			printk(KERN_WARNING "clk: setting frequency of clock "
+				"per_id=%d to value %lu above upper limit %lu\n",
+				periph->id, parent_rate >> shift,
+				periph->range.max);
+		}
 	}
 
 	periph->auto_div = false;

--- a/drivers/spi/spi-atmel.c
+++ b/drivers/spi/spi-atmel.c
@@ -1250,13 +1250,12 @@ msg_done:
 static void atmel_spi_cleanup(struct spi_device *spi)
 {
 	struct atmel_spi_device	*asd = spi->controller_state;
-	unsigned		gpio = (unsigned) spi->controller_data;
 
 	if (!asd)
 		return;
 
 	spi->controller_state = NULL;
-	gpio_free(gpio);
+	gpio_free(asd->npcs_pin);
 	kfree(asd);
 }
 

--- a/sound/soc/atmel/Kconfig
+++ b/sound/soc/atmel/Kconfig
@@ -61,3 +61,14 @@ config SND_AT91_SOC_AFEB9260
 	select SND_SOC_TLV320AIC23_I2C
 	help
 	  Say Y here to support sound on AFEB9260 board.
+
+config SND_AT91_SOC_SAMA5D3_WM8904
+	tristate "SoC Audio support for WM8904 based SAMA5D3-EK board"
+	depends on ATMEL_SSC && SND_ATMEL_SOC
+	select SND_ATMEL_SOC_DMA
+	select SND_ATMEL_SOC_SSC
+	select SND_SOC_WM8904
+	select SND_SOC_DMAENGINE_PCM
+	help
+	  Say Y if you want to add support for audio SoC on an
+	  SAMA5D3-EK board which uses WM8904 audio codec.

--- a/sound/soc/atmel/Makefile
+++ b/sound/soc/atmel/Makefile
@@ -13,8 +13,11 @@ obj-$(CONFIG_SND_ATMEL_SOC_SSC) += snd-soc-atmel_ssc_dai.o
 snd-soc-sam9g20-wm8731-objs := sam9g20_wm8731.o
 snd-atmel-soc-wm8904-objs := atmel_wm8904.o
 snd-soc-sam9x5-wm8731-objs := sam9x5_wm8731.o
+snd-soc-sama5d3-wm8904-objs := sama5d3_wm8904.o
 
 obj-$(CONFIG_SND_AT91_SOC_SAM9G20_WM8731) += snd-soc-sam9g20-wm8731.o
 obj-$(CONFIG_SND_ATMEL_SOC_WM8904) += snd-atmel-soc-wm8904.o
 obj-$(CONFIG_SND_AT91_SOC_SAM9X5_WM8731) += snd-soc-sam9x5-wm8731.o
+obj-$(CONFIG_SND_AT91_SOC_SAMA5D3_WM8904) += snd-soc-sama5d3-wm8904.o
+
 obj-$(CONFIG_SND_AT91_SOC_AFEB9260) += snd-soc-afeb9260.o

--- a/sound/soc/atmel/sama5d3_wm8904.c
+++ b/sound/soc/atmel/sama5d3_wm8904.c
@@ -45,22 +45,7 @@ static int sama5d3_hw_params(struct snd_pcm_substream *substream,
 {
 	struct snd_soc_pcm_runtime *rtd = substream->private_data;
 	struct snd_soc_dai *codec_dai = rtd->codec_dai;
-	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
 	int ret;
-
-	ret = snd_soc_dai_set_fmt(codec_dai, SND_SOC_DAIFMT_I2S |
-		SND_SOC_DAIFMT_NB_NF | SND_SOC_DAIFMT_CBM_CFM);
-	if (ret < 0) {
-		pr_err("%s - Failed to set CODEC DAI format.", __func__);
-		return ret;
-	}
-
-	ret = snd_soc_dai_set_fmt(cpu_dai, SND_SOC_DAIFMT_I2S |
-		SND_SOC_DAIFMT_NB_NF | SND_SOC_DAIFMT_CBM_CFM);
-	if (ret < 0) {
-		pr_err("%s - Failed to set CPU DAI format.", __func__);
-		return ret;
-	}
 
 	ret = snd_soc_dai_set_pll(codec_dai, WM8904_FLL_MCLK, WM8904_FLL_MCLK,
 		32768, params_rate(params) * 256);
@@ -128,6 +113,9 @@ static struct snd_soc_dai_link sama5d3ek_dai = {
 	.stream_name = "WM8904 PCM",
 	.codec_dai_name = "wm8904-hifi",
 	.init = sama5d3_wm8904_init,
+	.dai_fmt = SND_SOC_DAIFMT_I2S
+		| SND_SOC_DAIFMT_NB_NF
+		| SND_SOC_DAIFMT_CBM_CFM,
 	.ops = &sama5d3_soc_ops,
 };
 

--- a/sound/soc/atmel/sama5d3_wm8904.c
+++ b/sound/soc/atmel/sama5d3_wm8904.c
@@ -211,8 +211,9 @@ static int sama5d3ek_wm8904_remove(struct platform_device *pdev)
 {
 	struct snd_soc_card *card = platform_get_drvdata(pdev);
 
-	atmel_ssc_put_audio(0);
+	clk_disable(mclk);
 	snd_soc_unregister_card(card);
+	atmel_ssc_put_audio(0);
 
 	return 0;
 }

--- a/sound/soc/atmel/sama5d3_wm8904.c
+++ b/sound/soc/atmel/sama5d3_wm8904.c
@@ -35,9 +35,10 @@
 
 static struct clk *mclk;
 
-static const struct snd_soc_dapm_route intercon[] = {
-	{ "MICBIAS", NULL, "IN1L" },
-	{ "Left Capture Mux", NULL, "MICBIAS" },
+static const struct snd_soc_dapm_widget sama5ek_dapm_widgets[] = {
+	SND_SOC_DAPM_HP("Headphone Jack", NULL),
+	SND_SOC_DAPM_MIC("Mic", NULL),
+	SND_SOC_DAPM_LINE("Line In Jack", NULL),
 };
 
 static int sama5d3_hw_params(struct snd_pcm_substream *substream,
@@ -68,34 +69,6 @@ static struct snd_soc_ops sama5d3_soc_ops = {
 	.hw_params = sama5d3_hw_params,
 };
 
-static int sama5d3_wm8904_init(struct snd_soc_pcm_runtime *rtd)
-{
-	struct snd_soc_codec *codec = rtd->codec;
-	struct snd_soc_dapm_context *dapm = &codec->dapm;
-
-	pr_debug("ASoC: sama5d3_wm8904_init() called\n");
-
-	snd_soc_dapm_nc_pin(dapm, "IN1R");
-	snd_soc_dapm_nc_pin(dapm, "IN3L");
-	snd_soc_dapm_nc_pin(dapm, "IN3R");
-	
-	snd_soc_dapm_nc_pin(dapm, "LINEOUTL");
-	snd_soc_dapm_nc_pin(dapm, "LINEOUTR");
-
-	snd_soc_dapm_enable_pin(dapm, "HPOUTL");
-	snd_soc_dapm_enable_pin(dapm, "HPOUTR");
-	snd_soc_dapm_enable_pin(dapm, "IN1L");
-	snd_soc_dapm_enable_pin(dapm, "IN2L");
-	snd_soc_dapm_enable_pin(dapm, "IN2R");
-	snd_soc_dapm_enable_pin(dapm, "MICBIAS");
-
-	snd_soc_dapm_add_routes(dapm, intercon, ARRAY_SIZE(intercon));
-
-	snd_soc_dapm_sync(dapm);
-
-	return 0;
-}
-
 int sama5d3ek_snd_suspend_pre(struct snd_soc_card *card)
 {
 	clk_disable(mclk);
@@ -112,7 +85,6 @@ static struct snd_soc_dai_link sama5d3ek_dai = {
 	.name = "WM8904",
 	.stream_name = "WM8904 PCM",
 	.codec_dai_name = "wm8904-hifi",
-	.init = sama5d3_wm8904_init,
 	.dai_fmt = SND_SOC_DAIFMT_I2S
 		| SND_SOC_DAIFMT_NB_NF
 		| SND_SOC_DAIFMT_CBM_CFM,
@@ -125,6 +97,9 @@ static struct snd_soc_card snd_soc_sama5d3ek = {
 	.num_links = 1,
 	.suspend_pre = sama5d3ek_snd_suspend_pre,
 	.resume_pre = sama5d3ek_snd_resume_pre,
+	.dapm_widgets = sama5ek_dapm_widgets,
+	.num_dapm_widgets = ARRAY_SIZE(sama5ek_dapm_widgets),
+	.fully_routed = true,
 };
 
 static int sama5d3ek_wm8904_dt_init(struct platform_device *pdev)

--- a/sound/soc/atmel/sama5d3_wm8904.c
+++ b/sound/soc/atmel/sama5d3_wm8904.c
@@ -1,0 +1,279 @@
+/*
+ * sama5d3ek_wm8904 - SoC audio for SAMA5D3EK based boards
+ *                    which use WM8904 as codec.
+ *
+ * Copyright (C) 2012 Atmel
+ *
+ * Author: Bo Shen <voice.shen@atmel.com>
+ * Based on sam9g20_wm8731.c by Sedji Gaouaou
+ *
+ */
+
+#include <linux/module.h>
+#include <linux/moduleparam.h>
+#include <linux/kernel.h>
+#include <linux/clk.h>
+#include <linux/io.h>
+#include <linux/platform_device.h>
+#include <linux/of.h>
+#include <linux/of_device.h>
+#include <linux/pinctrl/consumer.h>
+
+#include <sound/core.h>
+#include <sound/pcm.h>
+#include <sound/pcm_params.h>
+#include <sound/soc.h>
+
+#include <asm/mach-types.h>
+#include <mach/hardware.h>
+#include <mach/gpio.h>
+
+#include "../codecs/wm8904.h"
+#include "atmel_ssc_dai.h"
+
+#define MCLK_RATE 32768
+
+static struct clk *mclk;
+
+static const struct snd_soc_dapm_route intercon[] = {
+	{ "MICBIAS", NULL, "IN1L" },
+	{ "Left Capture Mux", NULL, "MICBIAS" },
+};
+
+static int sama5d3_hw_params(struct snd_pcm_substream *substream,
+	struct snd_pcm_hw_params *params)
+{
+	struct snd_soc_pcm_runtime *rtd = substream->private_data;
+	struct snd_soc_dai *codec_dai = rtd->codec_dai;
+	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
+	int ret;
+
+	ret = snd_soc_dai_set_fmt(codec_dai, SND_SOC_DAIFMT_I2S |
+		SND_SOC_DAIFMT_NB_NF | SND_SOC_DAIFMT_CBM_CFM);
+	if (ret < 0) {
+		pr_err("%s - Failed to set CODEC DAI format.", __func__);
+		return ret;
+	}
+
+	ret = snd_soc_dai_set_fmt(cpu_dai, SND_SOC_DAIFMT_I2S |
+		SND_SOC_DAIFMT_NB_NF | SND_SOC_DAIFMT_CBM_CFM);
+	if (ret < 0) {
+		pr_err("%s - Failed to set CPU DAI format.", __func__);
+		return ret;
+	}
+
+	ret = snd_soc_dai_set_pll(codec_dai, WM8904_FLL_MCLK, WM8904_FLL_MCLK,
+		32768, params_rate(params) * 256);
+	if (ret < 0) {
+		pr_err("%s - Failed to set CODEC PLL.", __func__);
+		return ret;
+	}
+
+	ret = snd_soc_dai_set_sysclk(codec_dai, WM8904_CLK_FLL,
+		12000000, SND_SOC_CLOCK_IN);
+	if (ret < 0) {
+		pr_err("%s - Failed to set WM8904 SYSCLK\n", __func__);
+		return ret;
+	}
+
+	return 0;
+}
+
+static struct snd_soc_ops sama5d3_soc_ops = {
+	.hw_params = sama5d3_hw_params,
+};
+
+static int sama5d3_wm8904_init(struct snd_soc_pcm_runtime *rtd)
+{
+	struct snd_soc_codec *codec = rtd->codec;
+	struct snd_soc_dapm_context *dapm = &codec->dapm;
+
+	pr_debug("ASoC: sama5d3_wm8904_init() called\n");
+
+	snd_soc_dapm_nc_pin(dapm, "IN1R");
+	snd_soc_dapm_nc_pin(dapm, "IN3L");
+	snd_soc_dapm_nc_pin(dapm, "IN3R");
+	
+	snd_soc_dapm_nc_pin(dapm, "LINEOUTL");
+	snd_soc_dapm_nc_pin(dapm, "LINEOUTR");
+
+	snd_soc_dapm_enable_pin(dapm, "HPOUTL");
+	snd_soc_dapm_enable_pin(dapm, "HPOUTR");
+	snd_soc_dapm_enable_pin(dapm, "IN1L");
+	snd_soc_dapm_enable_pin(dapm, "IN2L");
+	snd_soc_dapm_enable_pin(dapm, "IN2R");
+	snd_soc_dapm_enable_pin(dapm, "MICBIAS");
+
+	snd_soc_dapm_add_routes(dapm, intercon, ARRAY_SIZE(intercon));
+
+	snd_soc_dapm_sync(dapm);
+
+	return 0;
+}
+
+int sama5d3ek_snd_suspend_pre(struct snd_soc_card *card)
+{
+	clk_disable(mclk);
+	return 0;
+}
+
+int sama5d3ek_snd_resume_pre(struct snd_soc_card *card)
+{
+	clk_enable(mclk);
+	return 0;
+}
+
+static struct snd_soc_dai_link sama5d3ek_dai = {
+	.name = "WM8904",
+	.stream_name = "WM8904 PCM",
+	.codec_dai_name = "wm8904-hifi",
+	.init = sama5d3_wm8904_init,
+	.ops = &sama5d3_soc_ops,
+};
+
+static struct snd_soc_card snd_soc_sama5d3ek = {
+	.name = "WM8904 @ SAMA5D3",
+	.dai_link = &sama5d3ek_dai,
+	.num_links = 1,
+	.suspend_pre = sama5d3ek_snd_suspend_pre,
+	.resume_pre = sama5d3ek_snd_resume_pre,
+};
+
+static int sama5d3ek_wm8904_dt_init(struct platform_device *pdev)
+{
+	struct device_node *np = pdev->dev.of_node;
+	struct device_node *codec_np, *cpu_np;
+	struct snd_soc_card *card = &snd_soc_sama5d3ek;
+	int ret;
+
+	if (!np)
+		return -1;
+
+	ret = snd_soc_of_parse_card_name(card, "atmel,model");
+	if (ret) {
+		dev_err(&pdev->dev, "failed to parse card name\n");
+		return ret;
+	}
+
+	ret = snd_soc_of_parse_audio_routing(card, "atmel,audio-routing");
+	if (ret) {
+		dev_err(&pdev->dev, "failed to parse audio routing\n");
+		return ret;
+	}
+
+	cpu_np = of_parse_phandle(np, "atmel,ssc-controller", 0);
+	if (!cpu_np) {
+		dev_err(&pdev->dev, "failed to get dai and pcm info\n");
+		ret = -EINVAL;
+		return ret;
+	}
+	sama5d3ek_dai.cpu_of_node = cpu_np;
+	sama5d3ek_dai.platform_of_node = cpu_np;
+	of_node_put(cpu_np);
+
+	codec_np = of_parse_phandle(np, "atmel,audio-codec", 0);
+	if (!codec_np) {
+		dev_err(&pdev->dev, "failed to get codec info\n");
+		ret = -EINVAL;
+		return ret;
+	}
+	sama5d3ek_dai.codec_of_node = codec_np;
+	of_node_put(codec_np);
+
+	return 0;
+}
+
+static int sama5d3ek_wm8904_probe(struct platform_device *pdev)
+{
+	struct snd_soc_card *card = &snd_soc_sama5d3ek;
+	struct clk *clk_src;
+	struct pinctrl *pinctrl;
+	int ret;
+
+	pinctrl = devm_pinctrl_get_select_default(&pdev->dev);
+	if (IS_ERR(pinctrl)) {
+		dev_err(&pdev->dev, "failed to request pinctrl\n");
+		return PTR_ERR(pinctrl);
+	}
+
+	ret = atmel_ssc_set_audio(0);
+	if (ret != 0) {
+		dev_err(&pdev->dev, "failed to set SSC 0 for audio\n");
+		return ret;
+	}
+
+	card->dev = &pdev->dev;
+	ret = sama5d3ek_wm8904_dt_init(pdev);
+	if (ret) {
+		dev_err(&pdev->dev, "failed to init dt info\n");
+		goto err_set_audio;
+	}
+
+	mclk = clk_get(NULL, "pck0");
+	if (IS_ERR(mclk)) {
+		dev_err(&pdev->dev, "failed to get pck0\n");
+		ret = PTR_ERR(mclk);
+		goto err_set_audio;
+	}
+
+	clk_src = clk_get(NULL, "clk32k");
+	if (IS_ERR(clk_src)) {
+		dev_err(&pdev->dev, "failed to get clk32k\n");
+		ret = PTR_ERR(clk_src);
+		goto err_set_audio;
+	}
+
+	ret = clk_set_parent(mclk, clk_src);
+	clk_put(clk_src);
+	if (ret != 0) {
+		dev_err(&pdev->dev, "failed to set MCLK parent\n");
+		goto err_set_audio;
+	}
+	
+	dev_info(&pdev->dev, "setting pck0 to %dHz\n", MCLK_RATE);
+
+	clk_set_rate(mclk, MCLK_RATE);
+	clk_enable(mclk);
+
+	snd_soc_register_card(card);
+
+	return 0;
+
+err_set_audio:
+	atmel_ssc_put_audio(0);
+	return ret;
+}
+
+static int sama5d3ek_wm8904_remove(struct platform_device *pdev)
+{
+	struct snd_soc_card *card = platform_get_drvdata(pdev);
+
+	atmel_ssc_put_audio(0);
+	snd_soc_unregister_card(card);
+
+	return 0;
+}
+
+#ifdef CONFIG_OF
+static const struct of_device_id sama5d3ek_wm8904_dt_ids[] = {
+	{ .compatible = "atmel,sama5d3ek-wm8904", },
+	{ }
+};
+#endif
+
+static struct platform_driver sama5d3ek_wm8904_driver = {
+	.driver = {
+		.name = "sama5d3ek-audio",
+		.owner = THIS_MODULE,
+		.of_match_table = of_match_ptr(sama5d3ek_wm8904_dt_ids),
+	},
+	.probe = sama5d3ek_wm8904_probe,
+	.remove = sama5d3ek_wm8904_remove,
+};
+
+module_platform_driver(sama5d3ek_wm8904_driver);
+
+/* Module information */
+MODULE_AUTHOR("Bo Shen <voice.shen@atmel.com>");
+MODULE_DESCRIPTION("ALSA SoC machine driver for AT91SAMA5D3 - WM8904");
+MODULE_LICENSE("GPL");

--- a/sound/soc/atmel/sama5d3_wm8904.c
+++ b/sound/soc/atmel/sama5d3_wm8904.c
@@ -239,5 +239,5 @@ module_platform_driver(sama5d3ek_wm8904_driver);
 
 /* Module information */
 MODULE_AUTHOR("Bo Shen <voice.shen@atmel.com>");
-MODULE_DESCRIPTION("ALSA SoC machine driver for AT91SAMA5D3 - WM8904");
+MODULE_DESCRIPTION("ALSA SoC machine driver for SAMA5D3 - WM8904");
 MODULE_LICENSE("GPL");

--- a/sound/soc/atmel/sama5d3_wm8904.c
+++ b/sound/soc/atmel/sama5d3_wm8904.c
@@ -26,7 +26,6 @@
 
 #include <asm/mach-types.h>
 #include <mach/hardware.h>
-#include <mach/gpio.h>
 
 #include "../codecs/wm8904.h"
 #include "atmel_ssc_dai.h"

--- a/sound/soc/codecs/wm8904.c
+++ b/sound/soc/codecs/wm8904.c
@@ -2259,10 +2259,19 @@ static const struct i2c_device_id wm8904_i2c_id[] = {
 };
 MODULE_DEVICE_TABLE(i2c, wm8904_i2c_id);
 
+static const struct of_device_id wm8904_of_match[] = {
+	{ .compatible = "wlf,wm8904", },
+	{ .compatible = "wlf,wm8912", },
+	{ .compatible = "wlf,wm8918", },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, wm8904_of_match);
+
 static struct i2c_driver wm8904_i2c_driver = {
 	.driver = {
 		.name = "wm8904",
 		.owner = THIS_MODULE,
+		.of_match_table = wm8904_of_match,
 	},
 	.probe =    wm8904_i2c_probe,
 	.remove =   wm8904_i2c_remove,


### PR DESCRIPTION
There are several distinct things in this merge request:

1) It brings back audio codec support on at91sama5x EK. It was lost somewhere near migration to 3.6.9. Just reapplying old patches by Bo Shen is not enough now, and several more fixes in DT and wm8904 driver are required. In addition to provided commits, `i2c0` and `sound` DT entries should be manually enabled, since `i2c0` uses some common pins with ISI and is codec is disabled by default. Also in current config all DMA0 channels are already used but are strictly required for SSC operation, so we also need to free two DMA channels. After e.g. following extra patch and proper menuconfig settings audio works (tested with `mplayer -ao oss`), but it's not very stable.

```
diff --git a/arch/arm/boot/dts/sama5d35ek.dts b/arch/arm/boot/dts/sama5d35ek.dts
index d58d2f4..b84d250 100644
--- a/arch/arm/boot/dts/sama5d35ek.dts
+++ b/arch/arm/boot/dts/sama5d35ek.dts
@@ -28,6 +28,11 @@
                                status = "okay";
                        };
 
+                       i2c0: i2c@f0014000 {
+                               dmas = <>; /* free two DMA channels for ssc0 */
+                               status = "okay";
+                       };
+
                        i2c1: i2c@f0018000 {
                                status = "okay";
                        };
@@ -58,4 +63,8 @@
                        gpio-key,wakeup;
                };
        };
+
+       sound {
+               status = "okay";
+       };
 };
```

2) Added several missing DT definitions for various perepherals.

3) Fixes in clock code, UART and SPI drivers. UART fix deals with a rather obscure race condition. We run into problems with it while using high baud rates (>=230400) and "packet"-based protocol. Sometimes several last bytes of the packet were received and placed in ring buffer but not reported to TTY layer until more bytes arrived. In request-response protocols that means request timeout.
