### PR TITLE
mmc: atmel-mci: fix state error.

### DIFF
--- a/drivers/mmc/host/atmel-mci.c
+++ b/drivers/mmc/host/atmel-mci.c
@@ -1838,7 +1838,7 @@ static void atmci_tasklet_func(unsigned long priv)
 			}
 
 			atmci_request_end(host, host->mrq);
-			state = STATE_IDLE;
+			state = host->state;
 			break;
 		}
 	} while (state != prev_state);


### PR DESCRIPTION
atmci_request_end modify the host->state, but the "state = STATE_IDLE;" overwrite it.
