### PR TITLE
at91_pm_suspend_in_sram() must be 8-byte aligned

### DIFF
--- a/arch/arm/mach-at91/pm_suspend.S
+++ b/arch/arm/mach-at91/pm_suspend.S
@@ -85,6 +85,8 @@ tmp2	.req	r5
  *	@r2: base address of second SDRAM Controller or 0 if not present
  *	@r3: pm information
  */
+/* at91_pm_suspend_in_sram must be 8-byte aligned per the requirements of fncpy() */
+	.align 3
 ENTRY(at91_pm_suspend_in_sram)
 	/* Save registers on stack */
 	stmfd	sp!, {r4 - r12, lr}


### PR DESCRIPTION
...as per the requirements of fncpy().

I built a kernel for my custom board, and it kept crashing very early in the boot process.  Eventually I tracked it down to an BUG() triggered in fncpy() due to the fact that, in my particular kernel, at91_pm_suspend_in_sram() was not 64-bit aligned.  (The EABI requires that PIC be 64-bit aligned so that PC relative loads and stores to 64 bit data works).

This trivial 1-line patch fixes this.