### PR TITLE
In the device driver, when members of the  struct spi_transfer cs_cha…

### DIFF
--- a/drivers/spi/spi-atmel.c
+++ b/drivers/spi/spi-atmel.c
@@ -1303,7 +1303,12 @@ static int atmel_spi_one_transfer(struct spi_master *master,
 		if (atmel_spi_dma_map_xfer(as, xfer) < 0)
 			return -ENOMEM;
 	}
-
+	
+	if (!as->cs_active){
+		cs_activate(as, msg->spi);
+		as->cs_active = true;
+	}
+	
 	atmel_spi_set_xfer_speed(as, msg->spi, xfer);
 
 	as->done_status = 0;


### PR DESCRIPTION
…nge = 1, CS pin no longer valid, in the next xfer transmission CS pin never be selected(low)
