### PR TITLE
SPI: at91: free correct GPIO

### DIFF
--- a/drivers/spi/spi-atmel.c
+++ b/drivers/spi/spi-atmel.c
@@ -1479,14 +1479,15 @@ msg_done:
 
 static void atmel_spi_cleanup(struct spi_device *spi)
 {
+	struct atmel_spi *as = spi_master_get_devdata(spi->master);
 	struct atmel_spi_device	*asd = spi->controller_state;
-	unsigned		gpio = (unsigned long) spi->controller_data;
 
 	if (!asd)
 		return;
 
 	spi->controller_state = NULL;
-	gpio_free(gpio);
+	if (as->use_cs_gpios)
+		gpio_free(asd->npcs_pin);
 	kfree(asd);
 }
 


### PR DESCRIPTION
If module is configured with DT, cleanup code releases invalid pin.
Since resource isn't freed, module cannot be reincerted. This
patch fixes the issue by releasing proper pin and doing this only
when it was actually requested before.