### PR TITLE
drm/atmel-hlcdc: use drm component API to access tda998x driver

### DIFF
--- a/drivers/gpu/drm/atmel-hlcdc/atmel_hlcdc_dc.h
+++ b/drivers/gpu/drm/atmel-hlcdc/atmel_hlcdc_dc.h
@@ -25,6 +25,7 @@
 #include <linux/clk.h>
 #include <linux/irqdomain.h>
 #include <linux/pwm.h>
+#include <linux/component.h>
 
 #include <drm/drm_atomic.h>
 #include <drm/drm_atomic_helper.h>
@@ -151,6 +152,7 @@ struct atmel_hlcdc_dc {
 		wait_queue_head_t wait;
 		bool pending;
 	} commit;
+	bool is_componentized;
 };
 
 extern struct atmel_hlcdc_formats atmel_hlcdc_plane_rgb_formats;
@@ -174,7 +176,10 @@ void atmel_hlcdc_crtc_suspend(struct drm_crtc *crtc);
 void atmel_hlcdc_crtc_resume(struct drm_crtc *crtc);
 
 int atmel_hlcdc_crtc_create(struct drm_device *dev);
+void atmel_hlcdc_crtc_set_simulate_vesa_sync(struct drm_crtc *c, bool enabled);
+void atmel_hlcdc_crtc_set_invert_pixel_clock(struct drm_crtc *c, bool enabled);
 
 int atmel_hlcdc_create_outputs(struct drm_device *dev);
+int atmel_hlcdc_get_external_components(struct device *dev, struct component_match **match);
 
 #endif /* DRM_ATMEL_HLCDC_H */

--- a/drivers/gpu/drm/i2c/tda998x_drv.c
+++ b/drivers/gpu/drm/i2c/tda998x_drv.c
@@ -22,6 +22,7 @@
 #include <sound/asoundef.h>
 
 #include <drm/drmP.h>
+#include <drm/drm_atomic_helper.h>
 #include <drm/drm_crtc_helper.h>
 #include <drm/drm_edid.h>
 #include <drm/drm_of.h>
@@ -878,7 +879,10 @@ tda998x_encoder_mode_fixup(struct drm_encoder *encoder,
 static int tda998x_connector_mode_valid(struct drm_connector *connector,
 					struct drm_display_mode *mode)
 {
-	if (mode->clock > 150000)
+	/* TDA19988 dotclock can go up to 165MHz */
+	struct tda998x_priv *priv = conn_to_tda998x_priv(connector);
+
+	if (mode->clock > ((priv->rev == TDA19988) ? 165000 : 150000))
 		return MODE_CLOCK_HIGH;
 	if (mode->htotal >= BIT(13))
 		return MODE_BAD_HVALUE;
@@ -1149,6 +1153,8 @@ static int tda998x_connector_get_modes(struct drm_connector *connector)
 {
 	struct tda998x_priv *priv = conn_to_tda998x_priv(connector);
 	struct edid *edid;
+	u32 bus_format = MEDIA_BUS_FMT_RGB888_1X24;
+	int ret;
 	int n;
 
 	/*
@@ -1176,6 +1182,10 @@ static int tda998x_connector_get_modes(struct drm_connector *connector)
 	n = drm_add_edid_modes(connector, edid);
 	priv->is_hdmi_sink = drm_detect_hdmi_monitor(edid);
 	kfree(edid);
+
+	ret = drm_display_info_set_bus_formats(&connector->display_info, &bus_format, 1);
+	if (ret)
+		return ret;
 
 	return n;
 }
@@ -1392,11 +1402,24 @@ static void tda998x_connector_destroy(struct drm_connector *connector)
 	drm_connector_cleanup(connector);
 }
 
+static int tda998x_connector_dpms(struct drm_connector *connector, int mode)
+{
+	DRM_DEBUG_DRIVER("connector_dpms: %d\n", mode);
+
+	if (drm_core_check_feature(connector->dev, DRIVER_ATOMIC))
+		return drm_atomic_helper_connector_dpms(connector, mode);
+	else
+		return drm_helper_connector_dpms(connector, mode);
+}
+
 static const struct drm_connector_funcs tda998x_connector_funcs = {
-	.dpms = drm_helper_connector_dpms,
+	.dpms = tda998x_connector_dpms,
+	.reset = drm_atomic_helper_connector_reset,
 	.fill_modes = drm_helper_probe_single_connector_modes,
 	.detect = tda998x_connector_detect,
 	.destroy = tda998x_connector_destroy,
+	.atomic_duplicate_state = drm_atomic_helper_connector_duplicate_state,
+	.atomic_destroy_state = drm_atomic_helper_connector_destroy_state,
 };
 
 static int tda998x_bind(struct device *dev, struct device *master, void *data)
@@ -1453,7 +1476,6 @@ static int tda998x_bind(struct device *dev, struct device *master, void *data)
 	if (ret)
 		goto err_sysfs;
 
-	priv->connector.encoder = &priv->encoder;
 	drm_mode_connector_attach_encoder(&priv->connector, &priv->encoder);
 
 	return 0;
@@ -1472,6 +1494,7 @@ static void tda998x_unbind(struct device *dev, struct device *master,
 {
 	struct tda998x_priv *priv = dev_get_drvdata(dev);
 
+	drm_connector_unregister(&priv->connector);
 	drm_connector_cleanup(&priv->connector);
 	drm_encoder_cleanup(&priv->encoder);
 	tda998x_destroy(priv);


### PR DESCRIPTION
Add support for the TDA19988 HDMI transmitter and possibly other component based DRM drivers to the atmel-hlcdc driver. The idea is based on the tilcdc driver. Added device tree options to enable required timing changes. Change pixel clock divider settings to resolve incorrect clock output and reduce rounding to prevent clocking out of range.

Please test using DRM panels and bridges as I only have hardware using the TDA19988.
