### PR TITLE
Add OTG "like" capability for devices that share a transceiver between port A and device port

### DIFF
--- a/Documentation/devicetree/bindings/usb/atmel-usb.txt
+++ b/Documentation/devicetree/bindings/usb/atmel-usb.txt
@@ -20,8 +20,9 @@ Required properties:
 
 Optional properties:
  - id-gpio:  If present, specifies a gpio used for OTG "like" detection.
-   This is only applicable to host port A and the device port as they share a
-   transceiver.  Both OHCI and UDC nodes should have this property.
+   This is only applicable to devices that share a transceiver between 
+   host port A and the device port.  Both OHCI and UDC nodes should have
+   this property.
 
 usb0: ohci@00500000 {
 	compatible = "atmel,at91rm9200-ohci", "usb-ohci";
@@ -100,8 +101,9 @@ Optional properties:
  - atmel,vbus-gpio: If present, specifies a gpio that allows to detect whether
    vbus is present (USB is connected).
  - id-gpio:  If present, specifies a gpio used for OTG "like" detection.
-   This is only applicable to host port A and the device port as they share a
-   transceiver.  Both OHCI and UDC nodes should have this property.
+   This is only applicable to devices that share a transceiver between 
+   host port A and the device port.  Both OHCI and UDC nodes should have 
+   this property.
 
 Required child node properties:
  - name: Name of the endpoint.
@@ -121,6 +123,7 @@ usb2: gadget@fff78000 {
 	clocks = <&utmi>, <&udphs_clk>;
 	clock-names = "hclk", "pclk";
 	atmel,vbus-gpio = <&pioB 19 0>;
+	id-gpio = <&pioE, 26, 0>;
 
 	ep@0 {
 		reg = <0>;

--- a/Documentation/devicetree/bindings/usb/atmel-usb.txt
+++ b/Documentation/devicetree/bindings/usb/atmel-usb.txt
@@ -18,6 +18,11 @@ Required properties:
  - atmel,oc-gpio: If present, specifies a gpio that needs to be
    activated for the overcurrent detection.
 
+Optional properties:
+ - id-gpio:  If present, specifies a gpio used for OTG "like" detection.
+   This is only applicable to host port A and the device port as they share a
+   transceiver.  Both OHCI and UDC nodes should have this property.
+
 usb0: ohci@00500000 {
 	compatible = "atmel,at91rm9200-ohci", "usb-ohci";
 	reg = <0x00500000 0x100000>;
@@ -25,6 +30,7 @@ usb0: ohci@00500000 {
 	clock-names = "ohci_clk", "hclk", "uhpck";
 	interrupts = <20 4>;
 	num-ports = <2>;
+	id-gpio = <&pioE, 26, 0>;
 };
 
 EHCI
@@ -93,6 +99,9 @@ Required properties:
 Optional properties:
  - atmel,vbus-gpio: If present, specifies a gpio that allows to detect whether
    vbus is present (USB is connected).
+ - id-gpio:  If present, specifies a gpio used for OTG "like" detection.
+   This is only applicable to host port A and the device port as they share a
+   transceiver.  Both OHCI and UDC nodes should have this property.
 
 Required child node properties:
  - name: Name of the endpoint.

--- a/arch/arm/boot/dts/sama5d3xmb.dtsi
+++ b/arch/arm/boot/dts/sama5d3xmb.dtsi
@@ -168,6 +168,7 @@
 
 		usb0: gadget@00500000 {
 			atmel,vbus-gpio = <&pioD 29 GPIO_ACTIVE_HIGH>;
+			id-gpio = <&pioE 26 0>;
 			pinctrl-names = "default";
 			pinctrl-0 = <&pinctrl_usba_vbus>;
 			status = "okay";
@@ -179,6 +180,7 @@
 					   &pioD 26 GPIO_ACTIVE_LOW
 					   &pioD 27 GPIO_ACTIVE_LOW
 					  >;
+			id-gpio = <&pioE 26 0>;
 			status = "okay";
 		};
 

--- a/arch/arm/boot/dts/sama5d3xmb.dtsi
+++ b/arch/arm/boot/dts/sama5d3xmb.dtsi
@@ -168,7 +168,6 @@
 
 		usb0: gadget@00500000 {
 			atmel,vbus-gpio = <&pioD 29 GPIO_ACTIVE_HIGH>;
-			id-gpio = <&pioE 26 0>;
 			pinctrl-names = "default";
 			pinctrl-0 = <&pinctrl_usba_vbus>;
 			status = "okay";
@@ -180,7 +179,6 @@
 					   &pioD 26 GPIO_ACTIVE_LOW
 					   &pioD 27 GPIO_ACTIVE_LOW
 					  >;
-			id-gpio = <&pioE 26 0>;
 			status = "okay";
 		};
 

--- a/drivers/usb/gadget/udc/atmel_usba_udc.h
+++ b/drivers/usb/gadget/udc/atmel_usba_udc.h
@@ -356,6 +356,8 @@ struct usba_udc {
 
 	u16 test_mode;
 	int vbus_prev;
+	int id_prev;
+	int id_pin;
 
 	u32 int_enb_cache;
 

--- a/drivers/usb/host/ohci-at91.c
+++ b/drivers/usb/host/ohci-at91.c
@@ -517,13 +517,14 @@ static irqreturn_t ohci_at91_otg_irq(int irq, void *data)
 	/* debounce */
 	mdelay(10);
 
-	/* OTG "like" connector can only be on port A as it shares a transceiver with the UDP, so vbus_pin index is 0 */
+	/* OTG "like" connector can only be on port A as it shares a
+	   transceiver with the UDP, so vbus_pin index is 0 */
 	if (gpio_is_valid(pdata->id_gpio)) {
 		if (gpio_get_value(pdata->id_gpio)) {
-			/* id pin is high, we are not a host so set VBUS low (inverter on hw)*/
+			/* id pin is high, we are not a host so set VBUS low */
 			gpio_direction_output(pdata->vbus_pin[0], 1);
 		} else {
-			/* id pin is low, we are now a host port, set VBUS hi (inverter on hw)*/
+			/* id pin is low, we are now a host, set VBUS hi */
 			gpio_direction_output(pdata->vbus_pin[0], 0);
 		}
 	}
@@ -643,7 +644,7 @@ static int ohci_hcd_at91_drv_probe(struct platform_device *pdev)
 		}
 	}
 
-	/* OTG "like" connector can only be on port A as it shares a transceiver with the UDP, so vbus_pin index is 0 */
+	/* Get ID pin (if present) for OTG "like" detection */
 	pdata->id_gpio = of_get_named_gpio_flags(np, "id-gpio", 0, &flags);
 
 	if (gpio_is_valid(pdata->id_gpio)) {

--- a/include/linux/usb/atmel_usba_udc.h
+++ b/include/linux/usb/atmel_usba_udc.h
@@ -16,6 +16,7 @@ struct usba_ep_data {
 struct usba_platform_data {
 	int			vbus_pin;
 	int			vbus_pin_inverted;
+	int 			id_pin;
 	int			num_ep;
 	struct usba_ep_data	ep[0];
 };


### PR DESCRIPTION
This patch is based on an Atmel app note from 2013, but updated for devicetree and later kernels.  It adds support to allow an OTG cable to be detected and switch host and device roles on the fly.  App note:
http://www.atmel.com/Images/Atmel_11201_USB-OTG-Like-Connector-Implementation_SAM9G-SAM9X-SAMA5D3_Application-Note.pdf

Tested on SAMA5D3x-EK.