### PR TITLE
net: wireless: support of_get_mac_address new ERR_PTR error

### DIFF
--- a/drivers/net/wireless/ath/ath9k/init.c
+++ b/drivers/net/wireless/ath/ath9k/init.c
@@ -642,7 +642,7 @@ static int ath9k_of_init(struct ath_softc *sc)
 	}
 
 	mac = of_get_mac_address(np);
-	if (mac)
+	if (!IS_ERR(mac))
 		ether_addr_copy(common->macaddr, mac);
 
 	return 0;

--- a/drivers/net/wireless/mediatek/mt76/eeprom.c
+++ b/drivers/net/wireless/mediatek/mt76/eeprom.c
@@ -94,7 +94,7 @@ mt76_eeprom_override(struct mt76_dev *dev)
 		return;
 
 	mac = of_get_mac_address(np);
-	if (mac)
+	if (!IS_ERR(mac))
 		memcpy(dev->macaddr, mac, ETH_ALEN);
 #endif
 

--- a/drivers/net/wireless/ralink/rt2x00/rt2x00dev.c
+++ b/drivers/net/wireless/ralink/rt2x00/rt2x00dev.c
@@ -1007,7 +1007,7 @@ void rt2x00lib_set_mac_address(struct rt2x00_dev *rt2x00dev, u8 *eeprom_mac_addr
 	const char *mac_addr;
 
 	mac_addr = of_get_mac_address(rt2x00dev->dev->of_node);
-	if (mac_addr)
+	if (!IS_ERR(mac_addr))
 		ether_addr_copy(eeprom_mac_addr, mac_addr);
 
 	if (!is_valid_ether_addr(eeprom_mac_addr)) {


### PR DESCRIPTION
Wireless using rt2x00dev.c was segfaulting because of_get_mac_address() now returns an error code, so testing for NULL does not work anymore.

Please backport this patch so that we can use WiFi again in the Arietta board, for example.

> ...
INIT: version 2.88 booting
ieee80211 phy0: rt2x00_set_rt: Info - RT chipset 5390, rev 0502 detected
Unable to handle kernel paging request at virtual address fffffffe
pgd = (ptrval)
[fffffffe] *pgd=27ffd871, *pte=00000000, *ppte=00000000
Internal error: Oops: 37 [#1] PREEMPT ARM
Modules linked in:
CPU: 0 PID: 35 Comm: kworker/0:1 Not tainted 4.19.15+ #1
Hardware name: Atmel AT91SAM9
Workqueue: usb_hub_wq hub_event
PC is at rt2x00lib_set_mac_address+0x18/0x74
LR is at rt2x00lib_set_mac_address+0x14/0x74
pc : [<c033631c>]    lr : [<c0336318>]    psr: a0000013
sp : c7929b78  ip : 00000000  fp : c07adcb4
r10: c05b419c  r9 : c708bc00  r8 : c7ae6400
r7 : c7016f40  r6 : 00000000  r5 : c7016f3c  r4 : c7bc0c04
r3 : c6613a1c  r2 : c6613a1c  r1 : 60000013  r0 : fffffffe
Flags: NzCv  IRQs on  FIQs on  Mode SVC_32  ISA ARM  Segment none
Control: 0005317f  Table: 270b0000  DAC: 00000053
Process kworker/0:1 (pid: 35, stack limit = 0x(ptrval))
Stack: (0xc7929b78 to 0xc792a000)
9b60:                                                       c7016c40 c0344804
9b80: 00000502 c002e3e4 c7016c40 00000000 ffffffe0 c7016420 c7ae6400 c7026200
9ba0: c05b419c c034e1ec c7016c40 c0336f28 00000000 c70876e0 00000000 00000000
9bc0: 40000013 c7ae6478 c07adcb4 c7016c40 c7090e10 c7026200 c7016420 c7ae6400
9be0: c7026200 c05b419c c07adcb4 c033c268 c7026220 00000000 c7ae6400 c07adb1c
9c00: 00000000 c034d67c c7026220 c035d9b0 c7026220 00000000 00000000 c07d3a20
9c20: c07adb1c 00000003 fffffdfb c02c1064 c7026220 c07adb1c c7929cac c02c14e0
9c40: c7026254 c07d39fc 00000000 c02c13c8 c07adb1c c7026220 c05b419c c078e028
9c60: 00000000 c7929cac c02c14e0 c7026254 c07d39fc 00000000 c07adcb4 c02bf55c
9c80: 00000001 c794629c c7b6c834 c6613a1c c07adcb4 c7026220 c07adccc c078e028
9ca0: 00000001 c02c11e8 c7026220 c7026220 00000001 c6613a1c c7026220 c07adccc
9cc0: c7026220 c078e028 c7ae6478 c02c0370 c7026220 00000000 c7026228 c02be57c
9ce0: 00000000 c00df9e8 c7baa780 c0359a00 00000000 c6613a1c c7ae6400 c7ae6400
9d00: c7026854 c7026200 c7026854 c7ae6478 c06d7419 c7026220 c7b96800 c035bd50
9d20: 00000001 00000000 00000000 00000000 00001388 c014e954 c7026800 c7026850
9d40: 00000000 c7026854 00000004 c7ae6478 00000001 c7026850 c7baa784 00000001
9d60: 00000003 c7ae6400 00000001 00000000 c07d3a20 c07ae438 00000003 fffffdfb
9d80: c07adb8c c0365c94 c7ae6478 00000000 00000000 c02c1064 c7ae6478 c07ae438
9da0: c7929e14 c02c14e0 c7ae64ac c7810380 00000000 c02c13c8 c07ae438 c7ae6478
9dc0: c07adb8c c078e028 00000000 c7929e14 c02c14e0 c7ae64ac c7810380 00000000
9de0: c07adb8c c02bf55c 00000001 c794629c c79c32f4 c6613a1c c07adb8c c7ae6478
9e00: c07adccc c078e028 00000001 c02c11e8 c7ae6478 c7ae6478 00000001 c6613a1c
9e20: c7ae6478 c07adccc c7ae6478 c078e028 c7b96478 c02c0370 c7ae6478 00000000
9e40: c7ae6480 c02be57c c7b9ba60 39383128 c700313a c078e028 ffff6ad4 c6613a1c
9e60: c7929e80 c7ae6400 c7ae6478 c7baa820 c7b61e00 c7b96400 00000000 c7b61b94
9e80: c7b61a00 c035306c 00000003 00000001 c7b61a00 00000000 c7b61ef4 c7b61ef4
9ea0: 00000002 c7ae6400 c7b61e00 c7b96400 00000000 c7b61b94 c7b61a00 c0354718
9ec0: 00000008 c002dbe4 c7b61e00 00000001 c7b96400 c7b96800 00000000 c7b48020
9ee0: c7b48000 c7b964ac c7b61b94 00000003 c7b61b94 c7b61a08 00000064 00000002
9f00: c7929f4c 00000501 c78ab3e0 c6613a1c 00000000 c7816800 c7b61ef4 c0794338
9f20: c7ee6c00 00000000 00000000 c7b61ef8 00000008 c002dffc c7816800 c7b61ef4
9f40: c7816800 c7816814 ffffe000 c0794338 c079a300 c0794338 c079434c c002efb8
9f60: c790c0a0 c7887b80 c789da80 c7928000 c7816800 c002ecc8 c7831ec0 c7887b98
9f80: 00000000 c0033450 00000000 c789da80 c003333c 00000000 00000000 00000000
9fa0: 00000000 00000000 00000000 c00090e0 00000000 00000000 00000000 00000000
9fc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
9fe0: 00000000 00000000 00000000 00000000 00000013 00000000 00000000 00000000
[<c033631c>] (rt2x00lib_set_mac_address) from [<c0344804>] (rt2800_probe_hw+0x100/0xe70)
[<c0344804>] (rt2800_probe_hw) from [<c034e1ec>] (rt2800usb_probe_hw+0xc/0x4c)
[<c034e1ec>] (rt2800usb_probe_hw) from [<c0336f28>] (rt2x00lib_probe_dev+0x1a4/0x704)
[<c0336f28>] (rt2x00lib_probe_dev) from [<c033c268>] (rt2x00usb_probe+0x194/0x1e8)
[<c033c268>] (rt2x00usb_probe) from [<c034d67c>] (rt2800usb_probe+0xc/0x18)
[<c034d67c>] (rt2800usb_probe) from [<c035d9b0>] (usb_probe_interface+0x1b8/0x1f0)
[<c035d9b0>] (usb_probe_interface) from [<c02c1064>] (really_probe+0x1d4/0x2ac)
[<c02c1064>] (really_probe) from [<c02c13c8>] (driver_probe_device+0x144/0x15c)
[<c02c13c8>] (driver_probe_device) from [<c02bf55c>] (bus_for_each_drv+0xa4/0xbc)
[<c02bf55c>] (bus_for_each_drv) from [<c02c11e8>] (__device_attach+0xac/0x124)
[<c02c11e8>] (__device_attach) from [<c02c0370>] (bus_probe_device+0x24/0x80)
[<c02c0370>] (bus_probe_device) from [<c02be57c>] (device_add+0x430/0x564)
[<c02be57c>] (device_add) from [<c035bd50>] (usb_set_configuration+0x664/0x6d4)
[<c035bd50>] (usb_set_configuration) from [<c0365c94>] (generic_probe+0x4c/0x78)
[<c0365c94>] (generic_probe) from [<c02c1064>] (really_probe+0x1d4/0x2ac)
[<c02c1064>] (really_probe) from [<c02c13c8>] (driver_probe_device+0x144/0x15c)
[<c02c13c8>] (driver_probe_device) from [<c02bf55c>] (bus_for_each_drv+0xa4/0xbc)
[<c02bf55c>] (bus_for_each_drv) from [<c02c11e8>] (__device_attach+0xac/0x124)
[<c02c11e8>] (__device_attach) from [<c02c0370>] (bus_probe_device+0x24/0x80)
[<c02c0370>] (bus_probe_device) from [<c02be57c>] (device_add+0x430/0x564)
[<c02be57c>] (device_add) from [<c035306c>] (usb_new_device+0x2a8/0x3bc)
[<c035306c>] (usb_new_device) from [<c0354718>] (hub_event+0xc98/0xf24)
[<c0354718>] (hub_event) from [<c002dffc>] (process_one_work+0x1f0/0x328)
[<c002dffc>] (process_one_work) from [<c002efb8>] (worker_thread+0x2f0/0x488)
[<c002efb8>] (worker_thread) from [<c0033450>] (kthread+0x114/0x12c)
[<c0033450>] (kthread) from [<c00090e0>] (ret_from_fork+0x14/0x34)
Exception stack(0xc7929fb0 to 0xc7929ff8)
9fa0:                                     00000000 00000000 00000000 00000000
9fc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
9fe0: 00000000 00000000 00000000 00000000 00000013 00000000
Code: e1a04001 e5930138 eb028ab4 e3500000 (11d030b0) 
---[ end trace 26da2151013e3d30 ]---

Here is the text of the original patch:

There was NVMEM support added to of_get_mac_address, so it could now return
ERR_PTR encoded error values, so we need to adjust all current users of
of_get_mac_address to this new fact.

Signed-off-by: Petr Štetiar <ynezz@true.cz>
Signed-off-by: David S. Miller <davem@davemloft.net>
