### PR TITLE
net: macb: manage Rx BNA error to avoid race condition

### DIFF
--- a/drivers/net/ethernet/cadence/macb_main.c
+++ b/drivers/net/ethernet/cadence/macb_main.c
@@ -1144,7 +1144,7 @@ static int gem_rx(struct macb_queue *queue, struct napi_struct *napi,
 		count++;
 
 		if (!(ctrl & MACB_BIT(RX_SOF) && ctrl & MACB_BIT(RX_EOF))) {
-			netdev_err(bp->dev,
+			netdev_warn(bp->dev,
 				   "not whole frame pointed by descriptor\n");
 			bp->dev->stats.rx_dropped++;
 			queue->stats.rx_dropped++;


### PR DESCRIPTION
In case of BNA error (Buffer Not Available), the GMAC sets the BNA bit and
triggers a RCOMP interrupt. At the next end of frame received, if the BNA
condition is not corrected, only the BNA bit is set but no more RCOMP
interrupts are generated. A RCOMP interrupt is guaranteed if the DMA queue
base address is written while Rx is disabled fixing the race condition.

Signed-off-by: Yannick Lanz <yannick.lanz@wifx.net>

**EDIT:** The commit has changed since this original one.