### PR TITLE
atmel/nand-controller.c: ECC statistics corrected counter update added.

### DIFF
--- a/drivers/mtd/nand/raw/atmel/nand-controller.c
+++ b/drivers/mtd/nand/raw/atmel/nand-controller.c
@@ -813,8 +813,10 @@ static int atmel_nand_pmecc_correct_data(struct nand_chip *chip, void *buf,
 							  NULL, 0,
 							  chip->ecc.strength);
 
-		if (ret >= 0)
+		if (ret >= 0) {
+			mtd->ecc_stats.corrected += ret;
 			max_bitflips = max(ret, max_bitflips);
+		}
 		else
 			mtd->ecc_stats.failed++;
 

--- a/drivers/mtd/nand/raw/atmel/nand-controller.c
+++ b/drivers/mtd/nand/raw/atmel/nand-controller.c
@@ -817,8 +817,9 @@ static int atmel_nand_pmecc_correct_data(struct nand_chip *chip, void *buf,
 			mtd->ecc_stats.corrected += ret;
 			max_bitflips = max(ret, max_bitflips);
 		}
-		else
+		else {
 			mtd->ecc_stats.failed++;
+		}
 
 		databuf += chip->ecc.size;
 		eccbuf += chip->ecc.bytes;


### PR DESCRIPTION
During work on some issues related to ECC error correction, I discovered that the Atmel NAND controller driver never updates the corrected counter, although in my test case there have been ECC corrections.

