### PR TITLE
pinctrl: fix mux-mask for PA7 so it can be set to A, B and C

### DIFF
--- a/arch/arm/boot/dts/at91-sam9x60ek.dts
+++ b/arch/arm/boot/dts/at91-sam9x60ek.dts
@@ -337,7 +337,7 @@
 &pinctrl {
 	atmel,mux-mask = <
 			 /*	A	B	C	*/
-			 0xFFFFFE7F 0xC0E0397F 0xEF00019D	/* pioA */
+			 0xFFFFFEFF 0xC0E039FF 0xEF00019D	/* pioA */
 			 0x03FFFFFF 0x02FC7E68 0x00780000	/* pioB */
 			 0xffffffff 0xF83FFFFF 0xB800F3FC	/* pioC */
 			 0x003FFFFF 0x003F8000 0x00000000	/* pioD */


### PR DESCRIPTION
According to the datasheet PA7 can be set to either function A, B or
C (see table 6-2 of DS60001579D). The previous value would permit just
configuring with function C.

Specifically I needed to use it in my hardware with function B to be able to
use CS 1 on SPI using flx4. This change would permit the needed configuration.

Signed-off-by: Federico Pellegrin <fede@evolware.org>