### PR TITLE
at_hdmac: double setup tx len (sama5d3)

### DIFF
--- a/drivers/dma/at_hdmac.c
+++ b/drivers/dma/at_hdmac.c
@@ -1306,7 +1306,6 @@ atc_prep_slave_sg(struct dma_chan *chan, struct scatterlist *sgl,
 			atdma_sg->len = len;
 			total_len += len;
 
-			desc->sg[i].len = len;
 			atdma_lli_chain(desc, i);
 		}
 		break;


### PR DESCRIPTION
atdma_sg->len and desc->sg[i].len are the same pointer to variable "len". Only need once.