### PR TITLE
ARM:dts:SAMA7D65: Fix the incorrect ranges address setting for flexcom9.

### DIFF
--- a/arch/arm/boot/dts/microchip/sama7d65.dtsi
+++ b/arch/arm/boot/dts/microchip/sama7d65.dtsi
@@ -1167,7 +1167,7 @@
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 43>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0xe281c000 0x800>;
+			ranges = <0x0 0xe2820000 0x800>;
 			status = "disabled";
 
 			i2c9: i2c@600 {


### PR DESCRIPTION
According to the SAMA7D65 SPEC, page 46, the starting address of FLEXCOM9 is 0xE2820000.

Incorrect configuration can cause the device to malfunction or even result in unpredictable behavior.