### PR TITLE
Update af_unix.c to increase default max_dgram_qlen

### DIFF
--- a/net/unix/af_unix.c
+++ b/net/unix/af_unix.c
@@ -3517,7 +3517,7 @@ static int __net_init unix_net_init(struct net *net)
 {
 	int i;
 
-	net->unx.sysctl_max_dgram_qlen = 10;
+	net->unx.sysctl_max_dgram_qlen = 512;
 	if (unix_sysctl_register(net))
 		goto out;
 


### PR DESCRIPTION
updated max_dgram_qlen, the default of 10 caused problems in BusyBox init system. This may be better to be in a Kconfig somewhere, but unsure where as this default is currently not configurable.